### PR TITLE
Feature/lazy bulk query

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,6 +274,20 @@ Query records:
 
     sf.bulk.Account.query(query)
 
+To retrieve large amounts of data, use 
+
+.. code-block:: python
+
+    query = 'SELECT Id, Name FROM Account'
+
+    # generator on the results page
+    fetch_results = sf.bulk.Account.query(query, lazy_operation=True)
+
+    # the generator provides the results list for every call
+    all_results = []
+    for list_results in fetch_results:
+      all_results.update(list_results)
+
 Query all records:
 
 QueryAll will return records that have been deleted because of a merge or delete. QueryAll will also return information about archived Task and Event records.
@@ -283,6 +297,20 @@ QueryAll will return records that have been deleted because of a merge or delete
     query = 'SELECT Id, Name FROM Account LIMIT 10'
 
     sf.bulk.Account.query_all(query)
+
+To retrieve large amounts of data, use 
+
+.. code-block:: python
+
+    query = 'SELECT Id, Name FROM Account'
+
+    # generator on the results page
+    fetch_results = sf.bulk.Account.query_all(query, lazy_operation=True)
+
+    # the generator provides the results list for every call
+    all_results = []
+    for list_results in fetch_results:
+      all_results.update(list_results)
 
 Delete records (soft deletion):
 

--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ To retrieve large amounts of data, use
     # generator on the results page
     fetch_results = sf.bulk.Account.query(query, lazy_operation=True)
 
-    # the generator provides the results list for every call
+    # the generator provides the list of results for every call to next()
     all_results = []
     for list_results in fetch_results:
       all_results.extend(list_results)
@@ -307,7 +307,7 @@ To retrieve large amounts of data, use
     # generator on the results page
     fetch_results = sf.bulk.Account.query_all(query, lazy_operation=True)
 
-    # the generator provides the results list for every call
+    # the generator provides the list of results for every call to next()
     all_results = []
     for list_results in fetch_results:
       all_results.extend(list_results)

--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ To retrieve large amounts of data, use
     # the generator provides the results list for every call
     all_results = []
     for list_results in fetch_results:
-      all_results.update(list_results)
+      all_results.extend(list_results)
 
 Query all records:
 
@@ -310,7 +310,7 @@ To retrieve large amounts of data, use
     # the generator provides the results list for every call
     all_results = []
     for list_results in fetch_results:
-      all_results.update(list_results)
+      all_results.extend(list_results)
 
 Delete records (soft deletion):
 


### PR DESCRIPTION
Hello,
In order to query large amounts of data without consuming a lot of memory, I edited the 
```SFBulkType::_get_batch_results```
 method to transform it into a generator. In addition
```SFBulkType::query```
and
```SFBulkType::query_all```
methods accept now a new *lazy_operation* parameter, to provide the users with two kinds of flows:
- lazy_operation = True, the generator is directly returned.
- lazy_operation = False (default), a list containing all results is constructed, providing consistency with already existing code.